### PR TITLE
fix: ignore spelling of a photo credit name #147

### DIFF
--- a/.codespellrc.txt
+++ b/.codespellrc.txt
@@ -1,0 +1,2 @@
+[codespell]
+ignore-words = Tru


### PR DESCRIPTION
fix #147